### PR TITLE
Feat: Prod with Railway

### DIFF
--- a/backend/.env.development
+++ b/backend/.env.development
@@ -1,1 +1,2 @@
+PORT=8080
 FRONTEND_API = http://localhost:5173

--- a/backend/.env.production
+++ b/backend/.env.production
@@ -1,0 +1,2 @@
+PORT=8080
+FRONTEND_API=http://frontend-production-88e6.up.railway.app

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,0 +1,1 @@
+VITE_API_URL=http://backend.railway.internal:8080/api


### PR DESCRIPTION
Moved `PORT=xxxx` from `.env` to `.env.production` and  `.env.development`

Using [railway](https://railway.com/dashboard) to host the [webapp](frontend-production-88e6.up.railway.app) 

